### PR TITLE
refactor(wasm): extract pipeline and formalize JS boundary contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npm run build       # production build → demo/dist
 ```
 
 There are no unit tests under `src/`'s own `#[cfg(test)]` modules in isolation
-from integration tests — both exist (e.g. `src/wasm.rs`'s `pipeline_tests`,
+from integration tests — both exist (e.g. `src/wasm/pipeline.rs`'s tests,
 `tests/build_trace.rs`). Run the whole suite with `cargo test --all-features`
 before considering a change done; CI fails the build on any clippy warning.
 
@@ -76,12 +76,15 @@ from `lib.rs` and the WASM layer wraps it rather than re-implementing it.
   `interval.rs` → `segment.rs`.
 - `calibration.rs` — recomputes remaining ETAs mid-race from one known
   elapsed-time data point; uses `AdvanceParams` struct internally.
-- `wasm/` (feature-gated) — `wasm.rs` is the `#[wasm_bindgen]` entry surface
-  (`parseGpx`, `parseWaypoints`, `parseMetadata`, `buildTrace`, `analyzeGpx`);
-  `wasm/trace.rs` wraps `Trace` as a JS-visible class; `wasm/dto.rs` defines
-  the serde-serializable shapes returned to JS; `wasm/options.rs` parses the
-  JS options object. This module only adapts — it must not contain analysis
-  logic that belongs in the core modules above.
+- `wasm/` (feature-gated) — `wasm.rs` is the thin `#[wasm_bindgen]` entry
+  surface (`parseGpx`, `parseWaypoints`, `parseMetadata`, `buildTrace`,
+  `analyzeGpx`); `wasm/pipeline.rs` holds the WASM-side orchestration shared by
+  entry points and methods; `wasm/js.rs` centralizes `JsValue` / serde glue and
+  warning helpers; `wasm/trace.rs` wraps the core `Trace` as a JS-visible class
+  (`Trace` in JS, `WasmTrace` in Rust for clarity); `wasm/dto.rs` defines the
+  serde-serializable shapes returned to JS; `wasm/options.rs` parses the JS
+  options object. This module only adapts — it must not contain analysis logic
+  that belongs in the core modules above.
 
 **WASM memory model**: data lives in WASM linear memory; JS holds a thin
 pointer. Only boundaries cross JS↔WASM — scalars are register-free, bulk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navigo"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Thomas <el.totorototo@gmail.com>"]
 edition = "2021"
 description = "GPS/geospatial data for Rust — trace analysis, GPX parsing, Minetti pace model, race route analysis (legs/sections/stages), live calibration."

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Prebuilt bindings are published to npm as [`@totorototo/navigo`](https://www.npm
 ### how it works
 
 All data lives in WASM linear memory. The JS side holds a thin pointer (`Trace`).
+Internally, the Rust wrapper type is named `WasmTrace` to distinguish it from the
+core crate's `Trace`, but the public JS API continues to expose `Trace`.
 Only the boundaries cross the WASM↔JS membrane — scalars are free (registers), bulk arrays are copied once on demand.
 
 ```
@@ -410,6 +412,27 @@ Trace stays in WASM memory
        ├── trace.locationsFlat         → one O(n) copy, cache it
        └── trace.free()               ← you must call this (no GC bridge)
 ```
+
+### failure contract
+
+The WASM API uses a small set of predictable failure channels:
+
+- **parse/build entry points return `null`** when they cannot produce a trace
+  (`buildTrace`, `parseGpx`, `parseGpxAll`, `analyzeGpx`);
+- **query-style methods return `undefined`** when there is simply no matching
+  result (`pointAtDistance`, `findClosestPoint`, `findClosestPointFrom`,
+  `sliceBetweenDistances`);
+- **validation/configuration failures return `null`** for high-level JSON
+  methods (`analyzeGpx`, `trace.analyze()`, `trace.recalibrate()`);
+- **range/index violations throw** only for APIs that are explicitly index-based
+  (`trace.getSection(...)`);
+- when JS serialization/deserialization itself fails, the WASM layer logs a
+  warning to `console.warn` and then uses that method's normal failure channel
+  (`null` or `undefined`).
+
+In other words: **`null` means “could not produce the requested payload”,
+`undefined` means “no query result”, and `throw` is reserved for explicit
+index/range contract violations.**
 
 ### build
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,32 +1,18 @@
 use wasm_bindgen::prelude::*;
 
-use crate::calibration::{self, BoundaryKind};
 use crate::{build_trace as core_build_trace, Location};
 
 mod dto;
+mod js;
 mod options;
+mod pipeline;
 mod trace;
 
-use dto::{
-    WasmGpxFull, WasmGpxMetadata, WasmRecalibration, WasmRouteAnalysis, WasmSectionStats,
-    WasmStageStats, WasmTraceSummary, WasmWaypoint,
-};
-use options::{WasmAnalyzeOptions, WasmRecalibrateOptions};
-pub use trace::Trace;
-
-// ── Console warning helper (no web-sys dep) ──────────────────────────────────
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = console, js_name = warn)]
-    fn console_warn(msg: &str);
-}
-
-/// Log a warning to the browser console (only in debug builds to avoid noise).
-#[inline]
-fn warn(msg: &str) {
-    console_warn(msg);
-}
+use dto::{WasmGpxFull, WasmGpxMetadata, WasmTraceSummary, WasmWaypoint};
+use js::{deserialize, serialize, serialize_or_undefined};
+use options::WasmAnalyzeOptions;
+use pipeline::{compute_route_analysis, parse_wasm_trace};
+pub use trace::WasmTrace as Trace;
 
 // ── Public entry points ───────────────────────────────────────────────────────
 
@@ -39,7 +25,10 @@ fn warn(msg: &str) {
 /// already attached. If you need the full race analysis in one shot, use
 /// [`analyzeGpx`] instead.
 ///
-/// Returns `null` when the GPX contains no valid track-points.
+/// Failure contract:
+/// - returns `null` when the GPX contains no valid track-points;
+/// - never throws for malformed GPX bytes — invalid/missing track-points are
+///   treated as an empty parse result.
 #[wasm_bindgen(js_name = "parseGpx")]
 pub fn parse_gpx(bytes: &[u8]) -> Option<Trace> {
     let locations = crate::gpx::parse_trace_points(bytes);
@@ -61,7 +50,10 @@ pub fn parse_gpx(bytes: &[u8]) -> Option<Trace> {
 /// of once for track-points only); use this when you'll call `.recalibrate()`
 /// repeatedly over the trace's lifetime, since the scan only happens once.
 ///
-/// Returns `null` when the GPX contains no valid track-points.
+/// Failure contract:
+/// - returns `null` when the GPX contains no valid track-points;
+/// - never throws for malformed GPX bytes — invalid/missing track-points are
+///   treated as an empty parse result.
 #[wasm_bindgen(js_name = "parseGpxAll")]
 pub fn parse_gpx_all(bytes: &[u8]) -> Option<Trace> {
     parse_wasm_trace(bytes)
@@ -73,13 +65,18 @@ pub fn parse_gpx_all(bytes: &[u8]) -> Option<Trace> {
 /// time, stopDuration }` objects, or an empty array when none are found.
 /// Call this only when you actually need waypoints — parsing is O(N) over
 /// the full byte slice.
+///
+/// Failure contract:
+/// - returns `[]` when no waypoints are found;
+/// - returns `undefined` only if JS serialization itself fails, after logging a
+///   warning to `console.warn`.
 #[wasm_bindgen(js_name = "parseWaypoints")]
 pub fn parse_waypoints_js(bytes: &[u8]) -> JsValue {
     let waypoints: Vec<WasmWaypoint> = crate::gpx::parse_waypoints(bytes)
         .iter()
         .map(Into::into)
         .collect();
-    serde_wasm_bindgen::to_value(&waypoints).unwrap_or(JsValue::UNDEFINED)
+    serialize_or_undefined(&waypoints, "parseWaypoints")
 }
 
 /// Parse only the `<metadata>` block (or root-level `<name>`/`<desc>`) from
@@ -87,10 +84,15 @@ pub fn parse_waypoints_js(bytes: &[u8]) -> JsValue {
 ///
 /// Returns a JS object `{ name, description }` (fields are `null` when absent).
 /// Call this only when you actually need the metadata.
+///
+/// Failure contract:
+/// - missing metadata still returns an object with `null` fields;
+/// - returns `undefined` only if JS serialization itself fails, after logging a
+///   warning to `console.warn`.
 #[wasm_bindgen(js_name = "parseMetadata")]
 pub fn parse_metadata_js(bytes: &[u8]) -> JsValue {
     let metadata = WasmGpxMetadata::from(&crate::gpx::parse_metadata(bytes));
-    serde_wasm_bindgen::to_value(&metadata).unwrap_or(JsValue::UNDEFINED)
+    serialize_or_undefined(&metadata, "parseMetadata")
 }
 
 /// Parse a GPX file and compute the full analysis in one call: trace metrics,
@@ -114,19 +116,21 @@ pub fn parse_metadata_js(bytes: &[u8]) -> JsValue {
 ///
 /// Returns a JS object with `{ trace, waypoints, legs, sections, stages, metadata }`
 /// or `null` when the GPX contains no valid track-points or `options` is malformed.
+///
+/// Failure contract:
+/// - parse/validation failures return `null`;
+/// - malformed `options` log a warning to `console.warn` before returning `null`;
+/// - serialization failures also log a warning and return `null`;
+/// - this function does not throw for malformed GPX/options input.
 #[wasm_bindgen(js_name = "analyzeGpx")]
 pub fn analyze_gpx(bytes: &[u8], options: JsValue) -> Option<JsValue> {
-    let options: WasmAnalyzeOptions = serde_wasm_bindgen::from_value(options)
-        .map_err(|e| warn(&format!("navigo: analyzeGpx options parse error: {e}")))
-        .ok()?;
+    let options: WasmAnalyzeOptions = deserialize(options, "analyzeGpx options")?;
     let trace = parse_wasm_trace(bytes)?;
 
     let analysis = compute_route_analysis(&trace, &options);
     let result = WasmGpxFull::new(WasmTraceSummary::from(trace.inner()), analysis);
 
-    serde_wasm_bindgen::to_value(&result)
-        .map_err(|e| warn(&format!("navigo: analyzeGpx serialization error: {e}")))
-        .ok()
+    serialize(&result, "analyzeGpx")
 }
 
 /// Build a trace from a flat `Float64Array` of interleaved coordinates:
@@ -139,6 +143,12 @@ pub fn analyze_gpx(bytes: &[u8], options: JsValue) -> Option<JsValue> {
 ///
 /// There's no GPX source here, so `.analyze()` on this trace will see no
 /// waypoints (empty `legs`, `sections`/`stages` both `null`).
+///
+/// Failure contract:
+/// - returns `null` when `flat` contains no complete points;
+/// - silently ignores a trailing 1- or 2-value remainder in `flat`
+///   (`chunks_exact(3)` semantics);
+/// - does not throw on malformed numeric payloads.
 #[wasm_bindgen(js_name = "buildTrace")]
 pub fn build_trace(flat: &[f64]) -> Option<Trace> {
     let locations: Vec<Location> = flat
@@ -159,197 +169,4 @@ pub fn build_trace(flat: &[f64]) -> Option<Trace> {
             },
         )
     })
-}
-
-/// Parse GPX `bytes` into a `Trace` that carries **all three** — track-points,
-/// waypoints and metadata — in a single (triple-scan) pass.
-///
-/// Shared by `analyzeGpx` and the public `parseGpxAll`, both of
-/// which need waypoints for the legs/sections/stages pipeline.
-fn parse_wasm_trace(bytes: &[u8]) -> Option<Trace> {
-    let parsed = crate::gpx::parse_all(bytes);
-    let inner = core_build_trace(&parsed.locations).ok()?;
-    Some(Trace::new(inner, parsed.waypoints, parsed.metadata))
-}
-
-/// Shared implementation behind `analyzeGpx` and `Trace::analyze`.
-fn compute_route_analysis(trace: &Trace, options: &WasmAnalyzeOptions) -> WasmRouteAnalysis {
-    let analysis_opts = options.to_analysis_options();
-
-    let legs = crate::leg::compute_from_waypoints(trace.inner(), trace.waypoints());
-    let sections =
-        crate::section::compute_from_waypoints(trace.inner(), trace.waypoints(), &analysis_opts);
-    let stages =
-        crate::stage::compute_from_waypoints(trace.inner(), trace.waypoints(), &analysis_opts);
-
-    WasmRouteAnalysis::new(
-        trace.waypoints().iter().map(Into::into).collect(),
-        legs.into_iter().map(Into::into).collect(),
-        sections.map(|ss| ss.into_iter().map(WasmSectionStats::from).collect()),
-        stages.map(|ss| ss.into_iter().map(WasmStageStats::from).collect()),
-        trace.metadata().into(),
-    )
-}
-
-/// Shared implementation behind `Trace::recalibrate`.
-///
-/// Runs `recalibrate_from_current` once per boundary kind — sections
-/// (checkpoint granularity) and stages (LifeBase granularity) — since each
-/// re-solves its own calibration factor against its own weather-per-range
-/// lookups rather than sharing one result.
-fn compute_recalibration(trace: &Trace, options: &WasmRecalibrateOptions) -> WasmRecalibration {
-    let analysis_opts = options.to_analysis_options();
-
-    let sections = calibration::recalibrate_from_current(
-        trace.inner(),
-        trace.waypoints(),
-        BoundaryKind::Section,
-        options.current_index(),
-        options.actual_elapsed_s(),
-        &analysis_opts,
-    );
-    let stages = calibration::recalibrate_from_current(
-        trace.inner(),
-        trace.waypoints(),
-        BoundaryKind::Stage,
-        options.current_index(),
-        options.actual_elapsed_s(),
-        &analysis_opts,
-    );
-
-    WasmRecalibration::new(sections, stages)
-}
-
-#[cfg(test)]
-mod pipeline_tests {
-    use super::*;
-
-    // 5 track-points plus 3 typed waypoints (Start / LifeBase / Arrival),
-    // each waypoint coinciding exactly with a track-point so
-    // `find_closest_point_from` resolves to distinct, increasing indices.
-    const SAMPLE_GPX: &[u8] = br#"<?xml version="1.0"?>
-<gpx>
-<trk><trkseg>
-<trkpt lat="45.000" lon="7.000"><ele>1000</ele></trkpt>
-<trkpt lat="45.010" lon="7.010"><ele>1100</ele></trkpt>
-<trkpt lat="45.020" lon="7.020"><ele>1050</ele></trkpt>
-<trkpt lat="45.030" lon="7.030"><ele>1200</ele></trkpt>
-<trkpt lat="45.040" lon="7.040"><ele>1150</ele></trkpt>
-</trkseg></trk>
-<wpt lat="45.000" lon="7.000"><name>Start</name><type>Start</type><time>2025-11-20T06:00:00Z</time></wpt>
-<wpt lat="45.020" lon="7.020"><name>Life Base</name><type>LifeBase</type><time>2025-11-20T10:00:00Z</time><stopDuration>1800</stopDuration></wpt>
-<wpt lat="45.040" lon="7.040"><name>Arrival</name><type>Arrival</type><time>2025-11-20T16:00:00Z</time></wpt>
-</gpx>"#;
-
-    #[test]
-    fn parse_gpx_returns_trace_points_only_no_waypoints_no_metadata() {
-        let trace = parse_gpx(SAMPLE_GPX).expect("sample GPX should parse");
-        assert_eq!(trace.inner().locations.len(), 5);
-        // parseGpx is the lean path — waypoints and metadata are NOT loaded.
-        assert!(trace.waypoints().is_empty());
-        assert!(trace.metadata().name.is_none());
-    }
-
-    #[test]
-    fn parse_gpx_all_loads_waypoints() {
-        let trace = parse_gpx_all(SAMPLE_GPX).expect("sample GPX should parse");
-        assert_eq!(trace.inner().locations.len(), 5);
-        assert_eq!(trace.waypoints().len(), 3);
-        assert_eq!(trace.waypoints()[0].name, "Start");
-    }
-
-    #[test]
-    fn parse_waypoints_js_returns_all_waypoints() {
-        // Test the underlying GPX parser — serde_wasm_bindgen::to_value cannot
-        // run on native targets, so we validate the raw parse result instead.
-        let waypoints = crate::gpx::parse_waypoints(SAMPLE_GPX);
-        assert_eq!(waypoints.len(), 3);
-        assert_eq!(waypoints[0].name, "Start");
-        assert_eq!(waypoints[1].name, "Life Base");
-        assert_eq!(waypoints[2].name, "Arrival");
-    }
-
-    #[test]
-    fn parse_metadata_js_falls_back_to_first_name_tag() {
-        // Test the underlying GPX parser — serde_wasm_bindgen::to_value cannot
-        // run on native targets, so we validate the raw parse result instead.
-        let metadata = crate::gpx::parse_metadata(SAMPLE_GPX);
-        // No <metadata> block in the fixture, so falls back to the first <name>
-        // anywhere in the document — here, the first waypoint's name.
-        assert_eq!(metadata.name.as_deref(), Some("Start"));
-    }
-
-    // Asserts on the serialized JSON shape (what JS actually receives) rather
-    // than poking at DTO internals, so the DTOs don't need test-only accessors.
-    #[test]
-    fn analyze_computes_legs_sections_and_stages_from_a_parsed_trace() {
-        // parse_wasm_trace (the full path) loads waypoints — required for analysis.
-        let trace = parse_wasm_trace(SAMPLE_GPX).expect("sample GPX should parse");
-        let analysis = compute_route_analysis(&trace, &WasmAnalyzeOptions::sample());
-        let json = serde_json::to_value(&analysis).expect("analysis should serialize");
-
-        assert_eq!(json["waypoints"].as_array().unwrap().len(), 3);
-        assert_eq!(json["legs"].as_array().unwrap().len(), 2);
-
-        let sections = json["sections"]
-            .as_array()
-            .expect("3 typed waypoints should yield sections");
-        assert_eq!(sections.len(), 2);
-        assert_eq!(sections[0]["stageIdx"], 0);
-        // Start (06:00) -> LifeBase (10:00): a 4h cutoff window.
-        assert_eq!(sections[0]["maxCompletionTime"], 4 * 3600);
-
-        let stages = json["stages"]
-            .as_array()
-            .expect("Start/LifeBase/Arrival should yield stages");
-        assert_eq!(stages.len(), 2);
-    }
-
-    #[test]
-    fn build_trace_path_has_no_waypoints_so_analyze_returns_empty_route_data() {
-        let flat = [7.0, 45.0, 1000.0, 7.01, 45.01, 1100.0];
-        let trace = build_trace(&flat).expect("flat coords should build a trace");
-        let analysis = compute_route_analysis(&trace, &WasmAnalyzeOptions::sample());
-        let json = serde_json::to_value(&analysis).expect("analysis should serialize");
-
-        assert!(json["waypoints"].as_array().unwrap().is_empty());
-        assert!(json["legs"].as_array().unwrap().is_empty());
-        assert!(json["sections"].is_null());
-        assert!(json["stages"].is_null());
-    }
-
-    // Asserts on the serialized JSON shape (what JS actually receives) rather
-    // than poking at DTO internals, so the DTOs don't need test-only accessors.
-    #[test]
-    fn recalibrate_computes_section_and_stage_etas_from_a_parsed_trace() {
-        // parse_wasm_trace (the full path) loads waypoints — required for recalibration.
-        let trace = parse_wasm_trace(SAMPLE_GPX).expect("sample GPX should parse");
-        // current_index=2 puts the runner mid-route; actual_elapsed_s well above
-        // the 300s gate so a non-trivial calibration factor is solved.
-        let recalibration =
-            compute_recalibration(&trace, &WasmRecalibrateOptions::sample(2, 3600.0));
-        let json = serde_json::to_value(&recalibration).expect("recalibration should serialize");
-
-        let sections = json["sections"]
-            .as_object()
-            .expect("Start/LifeBase/Arrival should yield section etas");
-        assert_eq!(sections["etas"].as_array().unwrap().len(), 2);
-        assert!(sections["calibrationFactor"].as_f64().unwrap() > 0.0);
-
-        let stages = json["stages"]
-            .as_object()
-            .expect("Start/LifeBase/Arrival should yield stage etas");
-        assert_eq!(stages["etas"].as_array().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn recalibrate_returns_null_for_both_kinds_with_fewer_than_two_boundaries() {
-        let flat = [7.0, 45.0, 1000.0, 7.01, 45.01, 1100.0];
-        let trace = build_trace(&flat).expect("flat coords should build a trace");
-        let recalibration = compute_recalibration(&trace, &WasmRecalibrateOptions::sample(0, 0.0));
-        let json = serde_json::to_value(&recalibration).expect("recalibration should serialize");
-
-        assert!(json["sections"].is_null());
-        assert!(json["stages"].is_null());
-    }
 }

--- a/src/wasm/js.rs
+++ b/src/wasm/js.rs
@@ -1,0 +1,52 @@
+use serde::{de::DeserializeOwned, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn console_warn(msg: &str);
+}
+
+/// Log a warning to the browser console.
+pub(super) fn warn(msg: &str) {
+    console_warn(msg);
+}
+
+pub(super) fn deserialize<T>(value: JsValue, context: &str) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    serde_wasm_bindgen::from_value(value)
+        .map_err(|e| warn(&format!("navigo: {context} parse error: {e}")))
+        .ok()
+}
+
+pub(super) fn serialize<T>(value: &T, context: &str) -> Option<JsValue>
+where
+    T: Serialize + ?Sized,
+{
+    serde_wasm_bindgen::to_value(value)
+        .map_err(|e| warn(&format!("navigo: {context} serialization error: {e}")))
+        .ok()
+}
+
+pub(super) fn serialize_or_null<T>(value: &T, context: &str) -> JsValue
+where
+    T: Serialize + ?Sized,
+{
+    serialize(value, context).unwrap_or(JsValue::NULL)
+}
+
+pub(super) fn serialize_or_undefined<T>(value: &T, context: &str) -> JsValue
+where
+    T: Serialize + ?Sized,
+{
+    serialize(value, context).unwrap_or(JsValue::UNDEFINED)
+}
+
+pub(super) fn serialize_silent<T>(value: &T) -> Option<JsValue>
+where
+    T: Serialize + ?Sized,
+{
+    serde_wasm_bindgen::to_value(value).ok()
+}

--- a/src/wasm/options.rs
+++ b/src/wasm/options.rs
@@ -90,7 +90,7 @@ impl WasmRecalibrateOptions {
 
 #[cfg(test)]
 impl WasmAnalyzeOptions {
-    /// Used by `wasm.rs`'s pipeline tests, which need a concrete options
+    /// Used by `pipeline.rs`'s tests, which need a concrete options
     /// value but live outside this module.
     pub(crate) fn sample() -> Self {
         Self {
@@ -104,7 +104,7 @@ impl WasmAnalyzeOptions {
 
 #[cfg(test)]
 impl WasmRecalibrateOptions {
-    /// Used by `wasm.rs`'s pipeline tests, which need a concrete options
+    /// Used by `pipeline.rs`'s tests, which need a concrete options
     /// value but live outside this module.
     pub(crate) fn sample(current_index: u32, actual_elapsed_s: f64) -> Self {
         Self {

--- a/src/wasm/pipeline.rs
+++ b/src/wasm/pipeline.rs
@@ -1,0 +1,211 @@
+use crate::calibration::{self, BoundaryKind};
+
+use super::dto::{WasmRecalibration, WasmRouteAnalysis, WasmSectionStats, WasmStageStats};
+use super::options::{WasmAnalyzeOptions, WasmRecalibrateOptions};
+use super::Trace;
+
+/// Parse GPX `bytes` into a `Trace` that carries **all three** — track-points,
+/// waypoints and metadata — in a single (triple-scan) pass.
+///
+/// Shared by `analyzeGpx` and the public `parseGpxAll`, both of
+/// which need waypoints for the legs/sections/stages pipeline.
+pub(super) fn parse_wasm_trace(bytes: &[u8]) -> Option<Trace> {
+    let parsed = crate::gpx::parse_all(bytes);
+    let inner = crate::build_trace(&parsed.locations).ok()?;
+    Some(Trace::new(inner, parsed.waypoints, parsed.metadata))
+}
+
+/// Shared implementation behind `analyzeGpx` and `Trace::analyze`.
+pub(super) fn compute_route_analysis(
+    trace: &Trace,
+    options: &WasmAnalyzeOptions,
+) -> WasmRouteAnalysis {
+    let analysis_opts = options.to_analysis_options();
+
+    let legs = crate::leg::compute_from_waypoints(trace.inner(), trace.waypoints());
+    let sections =
+        crate::section::compute_from_waypoints(trace.inner(), trace.waypoints(), &analysis_opts);
+    let stages =
+        crate::stage::compute_from_waypoints(trace.inner(), trace.waypoints(), &analysis_opts);
+
+    WasmRouteAnalysis::new(
+        trace.waypoints().iter().map(Into::into).collect(),
+        legs.into_iter().map(Into::into).collect(),
+        sections.map(|ss| ss.into_iter().map(WasmSectionStats::from).collect()),
+        stages.map(|ss| ss.into_iter().map(WasmStageStats::from).collect()),
+        trace.metadata().into(),
+    )
+}
+
+/// Shared implementation behind `Trace::recalibrate`.
+///
+/// Runs `recalibrate_from_current` once per boundary kind — sections
+/// (checkpoint granularity) and stages (LifeBase granularity) — since each
+/// re-solves its own calibration factor against its own weather-per-range
+/// lookups rather than sharing one result.
+pub(super) fn compute_recalibration(
+    trace: &Trace,
+    options: &WasmRecalibrateOptions,
+) -> WasmRecalibration {
+    let analysis_opts = options.to_analysis_options();
+
+    let sections = calibration::recalibrate_from_current(
+        trace.inner(),
+        trace.waypoints(),
+        BoundaryKind::Section,
+        options.current_index(),
+        options.actual_elapsed_s(),
+        &analysis_opts,
+    );
+    let stages = calibration::recalibrate_from_current(
+        trace.inner(),
+        trace.waypoints(),
+        BoundaryKind::Stage,
+        options.current_index(),
+        options.actual_elapsed_s(),
+        &analysis_opts,
+    );
+
+    WasmRecalibration::new(sections, stages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{build_trace, parse_gpx, parse_gpx_all};
+    use super::*;
+    use crate::wasm::dto::WasmWaypoint;
+
+    // 5 track-points plus 3 typed waypoints (Start / LifeBase / Arrival),
+    // each waypoint coinciding exactly with a track-point so
+    // `find_closest_point_from` resolves to distinct, increasing indices.
+    const SAMPLE_GPX: &[u8] = br#"<?xml version="1.0"?>
+<gpx>
+<trk><trkseg>
+<trkpt lat="45.000" lon="7.000"><ele>1000</ele></trkpt>
+<trkpt lat="45.010" lon="7.010"><ele>1100</ele></trkpt>
+<trkpt lat="45.020" lon="7.020"><ele>1050</ele></trkpt>
+<trkpt lat="45.030" lon="7.030"><ele>1200</ele></trkpt>
+<trkpt lat="45.040" lon="7.040"><ele>1150</ele></trkpt>
+</trkseg></trk>
+<wpt lat="45.000" lon="7.000"><name>Start</name><type>Start</type><time>2025-11-20T06:00:00Z</time></wpt>
+<wpt lat="45.020" lon="7.020"><name>Life Base</name><type>LifeBase</type><time>2025-11-20T10:00:00Z</time><stopDuration>1800</stopDuration></wpt>
+<wpt lat="45.040" lon="7.040"><name>Arrival</name><type>Arrival</type><time>2025-11-20T16:00:00Z</time></wpt>
+</gpx>"#;
+
+    #[test]
+    fn parse_gpx_returns_trace_points_only_no_waypoints_no_metadata() {
+        let trace = parse_gpx(SAMPLE_GPX).expect("sample GPX should parse");
+        assert_eq!(trace.inner().locations.len(), 5);
+        // parseGpx is the lean path — waypoints and metadata are NOT loaded.
+        assert!(trace.waypoints().is_empty());
+        assert!(trace.metadata().name.is_none());
+    }
+
+    #[test]
+    fn parse_gpx_all_loads_waypoints() {
+        let trace = parse_gpx_all(SAMPLE_GPX).expect("sample GPX should parse");
+        assert_eq!(trace.inner().locations.len(), 5);
+        assert_eq!(trace.waypoints().len(), 3);
+        assert_eq!(trace.waypoints()[0].name, "Start");
+    }
+
+    #[test]
+    fn parse_waypoints_js_returns_all_waypoints() {
+        // Test the underlying GPX parser — serde_wasm_bindgen::to_value cannot
+        // run on native targets, so we validate the raw parse result instead.
+        let waypoints: Vec<WasmWaypoint> = crate::gpx::parse_waypoints(SAMPLE_GPX)
+            .iter()
+            .map(Into::into)
+            .collect();
+        let json = serde_json::to_value(&waypoints).expect("waypoints should serialize");
+
+        assert_eq!(json.as_array().unwrap().len(), 3);
+        assert_eq!(json[0]["name"], "Start");
+        assert_eq!(json[1]["name"], "Life Base");
+        assert_eq!(json[2]["name"], "Arrival");
+    }
+
+    #[test]
+    fn parse_metadata_js_falls_back_to_first_name_tag() {
+        // Test the underlying GPX parser — serde_wasm_bindgen::to_value cannot
+        // run on native targets, so we validate the raw parse result instead.
+        let metadata = crate::gpx::parse_metadata(SAMPLE_GPX);
+        // No <metadata> block in the fixture, so falls back to the first <name>
+        // anywhere in the document — here, the first waypoint's name.
+        assert_eq!(metadata.name.as_deref(), Some("Start"));
+    }
+
+    // Asserts on the serialized JSON shape (what JS actually receives) rather
+    // than poking at DTO internals, so the DTOs don't need test-only accessors.
+    #[test]
+    fn analyze_computes_legs_sections_and_stages_from_a_parsed_trace() {
+        // parse_wasm_trace (the full path) loads waypoints — required for analysis.
+        let trace = parse_wasm_trace(SAMPLE_GPX).expect("sample GPX should parse");
+        let analysis = compute_route_analysis(&trace, &WasmAnalyzeOptions::sample());
+        let json = serde_json::to_value(&analysis).expect("analysis should serialize");
+
+        assert_eq!(json["waypoints"].as_array().unwrap().len(), 3);
+        assert_eq!(json["legs"].as_array().unwrap().len(), 2);
+
+        let sections = json["sections"]
+            .as_array()
+            .expect("3 typed waypoints should yield sections");
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0]["stageIdx"], 0);
+        // Start (06:00) -> LifeBase (10:00): a 4h cutoff window.
+        assert_eq!(sections[0]["maxCompletionTime"], 4 * 3600);
+
+        let stages = json["stages"]
+            .as_array()
+            .expect("Start/LifeBase/Arrival should yield stages");
+        assert_eq!(stages.len(), 2);
+    }
+
+    #[test]
+    fn build_trace_path_has_no_waypoints_so_analyze_returns_empty_route_data() {
+        let flat = [7.0, 45.0, 1000.0, 7.01, 45.01, 1100.0];
+        let trace = build_trace(&flat).expect("flat coords should build a trace");
+        let analysis = compute_route_analysis(&trace, &WasmAnalyzeOptions::sample());
+        let json = serde_json::to_value(&analysis).expect("analysis should serialize");
+
+        assert!(json["waypoints"].as_array().unwrap().is_empty());
+        assert!(json["legs"].as_array().unwrap().is_empty());
+        assert!(json["sections"].is_null());
+        assert!(json["stages"].is_null());
+    }
+
+    // Asserts on the serialized JSON shape (what JS actually receives) rather
+    // than poking at DTO internals, so the DTOs don't need test-only accessors.
+    #[test]
+    fn recalibrate_computes_section_and_stage_etas_from_a_parsed_trace() {
+        // parse_wasm_trace (the full path) loads waypoints — required for recalibration.
+        let trace = parse_wasm_trace(SAMPLE_GPX).expect("sample GPX should parse");
+        // current_index=2 puts the runner mid-route; actual_elapsed_s well above
+        // the 300s gate so a non-trivial calibration factor is solved.
+        let recalibration =
+            compute_recalibration(&trace, &WasmRecalibrateOptions::sample(2, 3600.0));
+        let json = serde_json::to_value(&recalibration).expect("recalibration should serialize");
+
+        let sections = json["sections"]
+            .as_object()
+            .expect("Start/LifeBase/Arrival should yield section etas");
+        assert_eq!(sections["etas"].as_array().unwrap().len(), 2);
+        assert!(sections["calibrationFactor"].as_f64().unwrap() > 0.0);
+
+        let stages = json["stages"]
+            .as_object()
+            .expect("Start/LifeBase/Arrival should yield stage etas");
+        assert_eq!(stages["etas"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn recalibrate_returns_null_for_both_kinds_with_fewer_than_two_boundaries() {
+        let flat = [7.0, 45.0, 1000.0, 7.01, 45.01, 1100.0];
+        let trace = build_trace(&flat).expect("flat coords should build a trace");
+        let recalibration = compute_recalibration(&trace, &WasmRecalibrateOptions::sample(0, 0.0));
+        let json = serde_json::to_value(&recalibration).expect("recalibration should serialize");
+
+        assert!(json["sections"].is_null());
+        assert!(json["stages"].is_null());
+    }
+}

--- a/src/wasm/trace.rs
+++ b/src/wasm/trace.rs
@@ -16,8 +16,8 @@ use super::options::{WasmAnalyzeOptions, WasmRecalibrateOptions};
 /// const trace = buildTrace(pts);
 /// registry.register(trace, trace);
 /// ```
-#[wasm_bindgen]
-pub struct Trace {
+#[wasm_bindgen(js_name = Trace)]
+pub struct WasmTrace {
     inner: crate::trace::Trace,
     waypoints: Vec<crate::waypoint::Waypoint>,
     metadata: crate::gpx::GpxMetadata,
@@ -26,7 +26,7 @@ pub struct Trace {
 // Plain (non-wasm_bindgen) constructor and accessors used internally by
 // `wasm.rs` — kept out of the `#[wasm_bindgen] impl` block below so they
 // aren't picked up as part of the JS-facing API.
-impl Trace {
+impl WasmTrace {
     pub(crate) fn new(
         inner: crate::trace::Trace,
         waypoints: Vec<crate::waypoint::Waypoint>,
@@ -52,8 +52,8 @@ impl Trace {
     }
 }
 
-#[wasm_bindgen]
-impl Trace {
+#[wasm_bindgen(js_class = Trace)]
+impl WasmTrace {
     // ── Scalar getters — free boundary crossing (passed in registers) ──────────
 
     #[wasm_bindgen(getter, js_name = "totalDistance")]
@@ -132,15 +132,23 @@ impl Trace {
 
     /// Returns `{ longitude, latitude, altitude }`, or `undefined` when the
     /// distance is negative / the trace has no matching point.
+    ///
+    /// Failure contract:
+    /// - query misses return `undefined`;
+    /// - serialization failure also returns `undefined`, without throwing.
     #[wasm_bindgen(js_name = "pointAtDistance")]
     pub fn point_at_distance(&self, dist_km: f64) -> Option<JsValue> {
         self.inner
             .point_at_distance(dist_km)
-            .and_then(|loc| serde_wasm_bindgen::to_value(loc).ok())
+            .and_then(super::js::serialize_silent)
     }
 
     /// Returns `{ location: { longitude, latitude, altitude }, index, distance }`,
     /// or `undefined` when no closest point is found.
+    ///
+    /// Failure contract:
+    /// - query misses return `undefined`;
+    /// - serialization failure also returns `undefined`, without throwing.
     #[wasm_bindgen(js_name = "findClosestPoint")]
     pub fn find_closest_point(
         &self,
@@ -158,6 +166,11 @@ impl Trace {
 
     /// Like `find_closest_point` but only searches from `start_from` onwards —
     /// use this on live-tracking loops to avoid snapping to an earlier position.
+    ///
+    /// Failure contract:
+    /// - query misses return `undefined`;
+    /// - out-of-bounds `start_from` behaves like a miss and returns `undefined`;
+    /// - serialization failure also returns `undefined`, without throwing.
     #[wasm_bindgen(js_name = "findClosestPointFrom")]
     pub fn find_closest_point_from(
         &self,
@@ -179,6 +192,10 @@ impl Trace {
 
     /// Flat `Float64Array` `[lon, lat, alt, …]` for all points between the two
     /// cumulative distances, or `undefined` on invalid input.
+    ///
+    /// Failure contract:
+    /// - invalid ranges return `undefined`;
+    /// - this method does not throw.
     #[wasm_bindgen(js_name = "sliceBetweenDistances")]
     pub fn slice_between_distances(&self, start_km: f64, end_km: f64) -> Option<Vec<f64>> {
         self.inner
@@ -187,7 +204,11 @@ impl Trace {
     }
 
     /// Flat `Float64Array` `[lon, lat, alt, …]` for the index range (inclusive).
-    /// Throws on out-of-bounds or invalid input.
+    ///
+    /// Failure contract:
+    /// - invalid ranges and out-of-bounds indices throw a `JsError`;
+    /// - unlike the query methods above, this method does not use `undefined`
+    ///   as its failure channel.
     #[wasm_bindgen(js_name = "getSection")]
     pub fn get_section(&self, start_index: u32, end_index: u32) -> Result<Vec<f64>, JsError> {
         self.inner
@@ -196,20 +217,32 @@ impl Trace {
             .map_err(|e| JsError::new(&e.to_string()))
     }
 
-    /// Returns `{ min_longitude, max_longitude, min_latitude, max_latitude }`.
+    /// Returns `{ minLongitude, maxLongitude, minLatitude, maxLatitude }`.
+    ///
+    /// Failure contract:
+    /// - returns `null` only if JS serialization fails;
+    /// - serialization failures log a warning to `console.warn`.
     pub fn area(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(self.inner.area()).unwrap_or(JsValue::NULL)
+        super::js::serialize_or_null(self.inner.area(), "Trace.area()")
     }
 
     /// Returns `{ positive, negative }` (raw, non-denoised elevation totals).
+    ///
+    /// Failure contract:
+    /// - returns `null` only if JS serialization fails;
+    /// - serialization failures log a warning to `console.warn`.
     pub fn elevation(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(self.inner.elevation()).unwrap_or(JsValue::NULL)
+        super::js::serialize_or_null(self.inner.elevation(), "Trace.elevation()")
     }
 
     /// Returns an array of climb objects:
     /// `[{ start_index, end_index, start_dist_km, climb_dist_km, elevation_gain, summit_elev, avg_gradient }, …]`
+    ///
+    /// Failure contract:
+    /// - returns `undefined` only if JS serialization fails;
+    /// - serialization failures log a warning to `console.warn`.
     pub fn climbs(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(self.inner.climbs()).unwrap_or(JsValue::UNDEFINED)
+        super::js::serialize_or_undefined(self.inner.climbs(), "Trace.climbs()")
     }
 
     /// Compute the race analysis (waypoints, legs, sections, stages) using
@@ -222,14 +255,16 @@ impl Trace {
     ///
     /// Returns a JS object with `{ waypoints, legs, sections, stages, metadata }`
     /// or `null` when `options` is malformed.
+    ///
+    /// Failure contract:
+    /// - malformed `options` return `null` and log a warning to `console.warn`;
+    /// - serialization failures also return `null` and log a warning;
+    /// - this method does not throw on user input errors.
     pub fn analyze(&self, options: JsValue) -> Option<JsValue> {
-        let options: WasmAnalyzeOptions = serde_wasm_bindgen::from_value(options)
-            .map_err(|e| super::warn(&format!("navigo: analyze() options error: {e}")))
-            .ok()?;
-        let analysis = super::compute_route_analysis(self, &options);
-        serde_wasm_bindgen::to_value(&analysis)
-            .map_err(|e| super::warn(&format!("navigo: analyze() serialization error: {e}")))
-            .ok()
+        let options: WasmAnalyzeOptions =
+            super::js::deserialize(options, "Trace.analyze() options")?;
+        let analysis = super::pipeline::compute_route_analysis(self, &options);
+        super::js::serialize(&analysis, "Trace.analyze()")
     }
 
     /// Live, mid-race ETA recalibration — corrects the static `.analyze()`
@@ -249,14 +284,18 @@ impl Trace {
     /// calibrated_base_pace_s_per_km, predicted_so_far_s, actual_elapsed_s,
     /// etas: [{ id, end_index, remaining_duration_s, cumulative_remaining_s }, …] }`.
     /// Returns `null` when `options` is malformed.
+    ///
+    /// Failure contract:
+    /// - malformed `options` return `null` and log a warning to `console.warn`;
+    /// - serialization failures also return `null` and log a warning;
+    /// - valid recalibration with insufficient typed boundaries yields
+    ///   `{ sections: null, stages: null }` rather than a top-level `null`;
+    /// - this method does not throw on user input errors.
     pub fn recalibrate(&self, options: JsValue) -> Option<JsValue> {
-        let options: WasmRecalibrateOptions = serde_wasm_bindgen::from_value(options)
-            .map_err(|e| super::warn(&format!("navigo: recalibrate() options error: {e}")))
-            .ok()?;
-        let recalibration = super::compute_recalibration(self, &options);
-        serde_wasm_bindgen::to_value(&recalibration)
-            .map_err(|e| super::warn(&format!("navigo: recalibrate() serialization error: {e}")))
-            .ok()
+        let options: WasmRecalibrateOptions =
+            super::js::deserialize(options, "Trace.recalibrate() options")?;
+        let recalibration = super::pipeline::compute_recalibration(self, &options);
+        super::js::serialize(&recalibration, "Trace.recalibrate()")
     }
 }
 
@@ -264,12 +303,11 @@ impl Trace {
 
 fn closest_result(result: Option<(&Location, usize, f64)>) -> Option<JsValue> {
     let (loc, idx, dist) = result?;
-    serde_wasm_bindgen::to_value(&ClosestPointResult {
+    super::js::serialize_silent(&ClosestPointResult {
         location: loc,
         index: idx as u32,
         distance: dist,
     })
-    .ok()
 }
 
 fn locs_to_flat(locs: &[Location]) -> Vec<f64> {


### PR DESCRIPTION
## What this changes

This PR refactors the WASM boundary layer to make responsibilities clearer and the JS-facing failure behavior explicit.

### 1) Extract orchestration from `src/wasm.rs`
- Added `src/wasm/pipeline.rs` for shared WASM-side orchestration:
  - full GPX parse into a WASM trace
  - route analysis assembly
  - recalibration assembly
- Kept `src/wasm.rs` focused on public `#[wasm_bindgen]` entry points.

### 2) Centralize JS/serde boundary glue
- Added `src/wasm/js.rs` to centralize:
  - `JsValue` deserialize/serialize helpers
  - `console.warn` logging on boundary conversion failures
  - `null` / `undefined` fallback helpers
- Replaced scattered direct conversion code with shared helpers.

### 3) Clarify Rust-side naming, keep JS API stable
- Renamed Rust wrapper type to `WasmTrace` in `src/wasm/trace.rs`.
- Kept the exported JS class name as `Trace` (no JS API break).

### 4) Keep tests with the pipeline module
- Pipeline tests now live in `src/wasm/pipeline.rs`.
- Updated test comments in `src/wasm/options.rs` accordingly.

### 5) Document boundary failure conventions
- Expanded public docs/comments in:
  - `src/wasm.rs`
  - `src/wasm/trace.rs`
  - `README.md` (new WASM failure-contract section)
- Explicitly documents when APIs return:
  - `null`
  - `undefined`
  - `throw` (`getSection` range/index contract)

## Why

- Reduce coupling and file bloat in the WASM entry module.
- Make boundary behavior predictable for JS consumers.
- Improve maintainability by centralizing conversion/error handling logic.

## Compatibility

- JS API remains stable (`Trace` class name unchanged).
- No intended behavioral regressions in analysis/recalibration outputs.

## Validation

Ran successfully:
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cd demo && npm run build` (includes wasm-pack build + Vite build)

## Notes

- `README.md` may show editor false positives if markdown code fences are parsed as Rust by tooling; Rust compile/test checks are green.